### PR TITLE
Use stable version and allow backport usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,8 @@
     "require": {
         "php": ">=5.6.4",
         "guzzlehttp/guzzle": "^6.2",
-        "illuminate/notifications": "^5.3@dev",
-        "illuminate/support": "^5.3@dev",
-        "illuminate/events": "^5.3@dev"
+        "illuminate/notifications": "5.3.*",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
@@ -43,6 +42,5 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit"
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
This PR makes use of the stable 5.3 version and also allows usage of the `laravel-notification-channels/backport` package, to use this notification channel with Laravel 5.1 and 5.2
