### PR TITLE
Allow Token overrides

### DIFF
--- a/src/HipChat.php
+++ b/src/HipChat.php
@@ -54,7 +54,17 @@ class HipChat
     {
         return $this->url;
     }
-
+    
+    /**
+     * Set the HipChat token to use.
+     *
+     * @param string
+     */
+    public function token($token)
+    {
+        $this->token = $token;
+    }
+    
     /**
      * Send a message.
      *

--- a/src/HipChat.php
+++ b/src/HipChat.php
@@ -54,7 +54,7 @@ class HipChat
     {
         return $this->url;
     }
-    
+
     /**
      * Set the HipChat token to use.
      *
@@ -64,7 +64,7 @@ class HipChat
     {
         $this->token = $token;
     }
-    
+
     /**
      * Send a message.
      *

--- a/src/HipChatChannel.php
+++ b/src/HipChatChannel.php
@@ -49,7 +49,7 @@ class HipChatChannel
         if (! $to = $to ?: $this->hipChat->room()) {
             throw CouldNotSendNotification::missingTo();
         }
-        
+
         if (! is_null($message->token)) {
             $this->hipChat->token($message->token);
         }

--- a/src/HipChatChannel.php
+++ b/src/HipChatChannel.php
@@ -49,6 +49,10 @@ class HipChatChannel
         if (! $to = $to ?: $this->hipChat->room()) {
             throw CouldNotSendNotification::missingTo();
         }
+        
+        if (! is_null($message->token)) {
+            $this->hipChat->token($message->token);
+        }
 
         try {
             $this->sendMessage($to, $message);

--- a/src/HipChatMessage.php
+++ b/src/HipChatMessage.php
@@ -12,6 +12,13 @@ class HipChatMessage
     public $room = '';
 
     /**
+     * The HipChat API token.
+     *
+     * @var string
+     */
+    public $token = null;
+
+    /**
      * A label to be shown in addition to the sender's name.
      *
      * @var string
@@ -101,6 +108,19 @@ class HipChatMessage
     public function room($room)
     {
         $this->room = $room;
+
+        return $this;
+    }
+
+    /**
+     * Set the HipChat token to use for this message.
+     *
+     * @param string $token
+     * @return $this
+     */
+    public function token($token)
+    {
+        $this->token = $token;
 
         return $this;
     }


### PR DESCRIPTION
I have to send a notification to 2-3 different HipChat accounts (using different tokens).

Currently from what I can see - there is no way to 'set' the token a message uses, as it all pulls it directly from the config.

This PR allows a message to optionally use an alternative token if required.