### PR TITLE
Handle empty values a little more intelligently

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,1 @@
 preset: laravel
-
-linting: true

--- a/src/CardAttribute.php
+++ b/src/CardAttribute.php
@@ -110,11 +110,11 @@ class CardAttribute
      */
     public function __construct($value = null, $label = null)
     {
-        if (! empty($value)) {
+        if (trim($value) !== '') {
             $this->value($value);
         }
 
-        if (! empty($label)) {
+        if (trim($label) !== '') {
             $this->label($label);
         }
     }
@@ -138,14 +138,18 @@ class CardAttribute
                 'label' => $this->value,
                 'url' => $this->url,
                 'style' => $this->style,
-            ]),
+            ], function ($value) {
+                return trim($value) !== '';
+            }),
         ];
 
         if (! empty($this->icon)) {
             $attribute['value']['icon'] = array_filter([
                 'url' => $this->icon,
                 'url@2x' => $this->icon2,
-            ]);
+            ], function ($value) {
+                return trim($value) !== '';
+            });
         }
 
         if (! empty($this->label)) {

--- a/tests/CardAttributeTest.php
+++ b/tests/CardAttributeTest.php
@@ -59,4 +59,39 @@ class CardAttributeTest extends \PHPUnit_Framework_TestCase
             ],
         ], $attribute->toArray());
     }
+
+    public function test_it_allows_empty_values_in_attributes()
+    {
+        $attribute = CardAttribute::create()
+            ->value(0)
+            ->label('Signups today');
+
+        $this->assertEquals([
+            'value' => [
+                'label' => '0',
+            ],
+            'label' => 'Signups today',
+        ], $attribute->toArray());
+    }
+
+    public function test_it_allows_empty_values_in_create()
+    {
+        $attribute = CardAttribute::create(0, 'Signups today');
+
+        $this->assertEquals([
+            'value' => [
+                'label' => '0',
+            ],
+            'label' => 'Signups today',
+        ], $attribute->toArray());
+
+        $attribute = new CardAttribute(0, 'Signups today');
+
+        $this->assertEquals([
+            'value' => [
+                'label' => '0',
+            ],
+            'label' => 'Signups today',
+        ], $attribute->toArray());
+    }
 }


### PR DESCRIPTION
When using an `empty` check or relying on a default `array_filter`, anything that is _considered_ to be empty will be ignored.

This means when using numeric values that can wind up being `0`, they will be interpreted as empty and stripped from the attribute.

Unfortunately, this is then passed to HipChat as an invalid attribute (one without a value label), which returns a 400 error. Furthermore, HipChat's API error messages aren't the simplest to decipher.

```json
{
    "value": {
        "style": "lozenge-current"
    },
    "label": "Signups today"
}
```

The change I'm proposing will handle the empty case a little more intelligently, resulting in the expected (and valid) attribute array.

```json
{
    "value": {
        "label": "0",
        "style": "lozenge-current"
    },
    "label": "Signups today"
}
```

Using `trim($value) !== ''` takes into account other actually empty values (empty string, `null`, `false`, etc.), so other functionality is preserved.